### PR TITLE
Fix for wild CGContext

### DIFF
--- a/UIImage+Color.m
+++ b/UIImage+Color.m
@@ -50,6 +50,7 @@
     
     UIImage *img = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
+    UIGraphicsEndImageContext();
     return img;
 }
 


### PR DESCRIPTION
There was a dangling CGContext because the number of image contexts began did not equal the number of image contexts ended.
